### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ This module can get easily devices and fetched snmp polling value.
    :target: http://travis-ci.org/mtoshi/cactidbadapter
 .. image:: https://coveralls.io/repos/mtoshi/cactidbadapter/badge.svg?branch=master
    :target: https://coveralls.io/r/mtoshi/cactidbadapter?branch=master
-.. image:: https://pypip.in/version/cactidbadapter/badge.svg
+.. image:: https://img.shields.io/pypi/v/cactidbadapter.svg
    :target: https://pypi.python.org/pypi/cactidbadapter/
    :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cactidbadapter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cactidbadapter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.